### PR TITLE
Spline interpolation in gg_boxcox

### DIFF
--- a/R/gg_boxcox.R
+++ b/R/gg_boxcox.R
@@ -19,7 +19,7 @@ gg_boxcox <- function(fitted.lm, showlambda = TRUE, lambdaSF = 3, scale.factor =
    handle_exception(fitted.lm, "gg_boxcox")
 
    # compute boxcox graph points
-   boxcox_object <- boxcox(fitted.lm, plotit = FALSE)
+   boxcox_object <- boxcox(fitted.lm, plotit = FALSE,interp=TRUE)
 
    # create new dataframe to hold all x and y points
    x <- unlist(boxcox_object$x)


### PR DESCRIPTION
To replicate the output of the default boxcox method, we must use spline interpolation. Spline interpolation is turned off by default when plotit is set to FALSE, so we must override the interp argument.